### PR TITLE
Additional error output and HTTP 404 header check

### DIFF
--- a/shcheck.py
+++ b/shcheck.py
@@ -171,17 +171,19 @@ def print_error(target, e):
     if isinstance(e, ValueError):
         print("Unknown url type")
 
-    if isinstance(e, urllib.error.HTTPError):
+    elif isinstance(e, urllib.error.HTTPError):
         print("[!] URL Returned an HTTP error: {}".format(
               colorize(str(e.code), 'error')))
 
-    if isinstance(e, urllib.error.URLError):
+    elif isinstance(e, urllib.error.URLError):
         if "CERTIFICATE_VERIFY_FAILED" in str(e.reason):
             print("SSL: Certificate validation error.\nIf you want to \
     ignore it run the program with the \"-d\" option.")
         else:
             print("Target host {} seems to be unreachable ({})".format(target, e.reason))
 
+    else:
+        print("{}".format(str(e)))
 
 def check_target(target, options):
     '''

--- a/shcheck.py
+++ b/shcheck.py
@@ -185,6 +185,7 @@ def print_error(target, e):
     else:
         print("{}".format(str(e)))
 
+
 def check_target(target, options):
     '''
     Just put a protocol to a valid IP and check if connection works,
@@ -212,8 +213,11 @@ def check_target(target, options):
     except http.client.UnknownProtocol as e:
         print("Unknown protocol: {}. Are you using a proxy? Try disabling it".format(e))
     except Exception as e:
-        print_error(target, e)
-        return None
+        if hasattr(e, 'code') and e.code == 404:
+            response = e
+        else:
+            print_error(target, e)
+            return None
 
     if response is not None:
         return response


### PR DESCRIPTION
Commit 1:
Added additional error output by selecting only the matching error class (or simply print the exception if no string representation is available). For example, a web server does not connect and only TCP RST is returned.
Commit 2:
Previously, HTTP 404 responses did not show any header information but here are headers to check.
Hence, if HTTP 404 is received the headers should be examined.

Thx!