### PR TITLE
fix(pip): Fix pip installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# IDE
+# Pycharm
+.idea
+
+# Python
+## Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@
 from setuptools import setup
 
 PACKAGE_NAME = "shcheck"
-VERSION = "1.6.6"
+VERSION = "1.6.7"
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         url="https://github.com/santoru/shcheck",
         scripts=[
-            "shcheck.py",
+            "shcheck/shcheck.py",
         ],
         python_requires='>=3'
     )


### PR DESCRIPTION
I installed the version 1.6.6 via pip. 
After installing, when running `shcheck.py --help`, I got the following error:

```
> shcheck.py --help
Traceback (most recent call last):
  File "/home/mlec/Tools/venv/bin/shcheck.py", line 20, in <module>
    from shcheck import shcheck
  File "/home/mlec/Tools/venv/bin/shcheck.py", line 20, in <module>
    from shcheck import shcheck
ImportError: cannot import name 'shcheck' from partially initialized module 'shcheck' (most likely due to a circular import)
```

This is due to the `shcheck.py` having the same name as the `shcheck` folder I think.

I made the following fix, and tested with `pip install .` and then running `shcheck.py --help` and I get no more error.