### PR TITLE
Add option to write output to file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@
 from setuptools import setup
 
 PACKAGE_NAME = "shcheck"
-VERSION = "1.7"
+VERSION = "1.8"
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()

--- a/shcheck/shcheck.py
+++ b/shcheck/shcheck.py
@@ -26,6 +26,7 @@ import sys
 import ssl
 import json
 import argparse
+import re
 
 
 def _make_colours(warning):
@@ -41,10 +42,16 @@ darkcolours  = _make_colours('\033[93m')
 lightcolours = _make_colours('\033[95m')
 
 
+def _strip_ansi_codes(string):
+    return re.sub(r'\x1b\[[0-9;]*m', '', string)
+
+
 # log - prints unless JSON output is set
-def log(string):
+def log(string, output_file=None):
     if options.json_output:
         return
+    if output_file:
+        output_file.write(_strip_ansi_codes(string) + "\n")
     print(string)
 
 
@@ -226,13 +233,15 @@ def check_target(target, req_headers=None, usemethod='HEAD'):
     return None
 
 
-def report(target, safe, unsafe):
-    log("-------------------------------------------------------")
-    log("[!] Analyzing headers for {}".format(colorize(target, 'info')))
-    log("[+] {} security header(s) present".format(colorize(str(safe), 'ok')))
+def report(target, safe, unsafe, output_file):
+    log("-------------------------------------------------------", output_file)
+    log("[!] Analyzing headers for {}".format(colorize(target, 'info')), output_file)
+    log("[+] {} security header(s) present".format(colorize(str(safe), 'ok')), output_file)
     log("[-] {} security header(s) missing".format(
-        colorize(str(unsafe), 'error')))
-    log("")
+            colorize(str(unsafe), 'error')),
+        output_file=output_file)
+    log("", output_file)
+
 
 def parse_csp(csp):
     unsafe_operators = ['unsafe-inline', 'unsafe-eval', 'unsafe-hashes', 'wasm-unsafe-eval', 'self']
@@ -264,6 +273,9 @@ def parse_options():
     parser.add_argument("-a", "--add-header", dest="custom_headers",
                         help="Add headers for the request e.g. 'Header: value'",
                         metavar="HEADER_STRING", action="append")
+    parser.add_argument("-o" , "--output", dest="output_file", default=False,
+                        help="Save the output to this file",
+                        metavar="OUTPUT_FILE")
     parser.add_argument('-d', "--disable-ssl-check", dest="ssldisabled",
                         default=False,
                         help="Disable SSL/TLS certificate validation",
@@ -324,6 +336,7 @@ def main():
     show_deprecated = options.show_deprecated
     hfile = options.hfile
     json_output = options.json_output
+    output_file = options.output_file
 
     banner()
     req_headers = dict(client_headers)
@@ -349,6 +362,10 @@ def main():
 
     build_opener(options.proxy, options.ssldisabled, options.no_follow)
 
+    if output_file:
+        # open and clear file to append logs
+        output_file = open(output_file, "w", encoding="utf-8")
+
     json_out = {}
     for target in targets:
         json_headers = {}
@@ -358,7 +375,8 @@ def main():
         safe = 0
         unsafe = 0
 
-        log("[*] Analyzing headers of {}".format(colorize(target, 'info')))
+        log("[*] Analyzing headers of {}".format(colorize(target, 'info')),
+            output_file=output_file)
 
         # Check if target is valid
         response = check_target(target, req_headers, usemethod=options.usemethod)
@@ -367,7 +385,8 @@ def main():
         rUrl = response.geturl()
         json_results = {}
 
-        log("[*] Effective URL: {}".format(colorize(rUrl, 'info')))
+        log("[*] Effective URL: {}".format(colorize(rUrl, 'info')),
+            output_file=output_file)
         headers = parse_headers(response.getheaders())
         json_headers[rUrl] = json_results
         json_results["present"] = {}
@@ -390,32 +409,37 @@ def main():
                 # Parse CSP headers
                 if lsafeh == 'content-security-policy':
                     log("[*] Header {} is present!".format(
-                            colorize(safeh, 'ok')))
+                            colorize(safeh, 'ok')),
+                        output_file=output_file)
                     parse_csp(headers.get(lsafeh))
 
                 # X-XSS-Protection Should be enabled
                 elif lsafeh == 'x-xss-protection' and headers.get(lsafeh) == '0':
                     log("[*] Header {} is present! (Value: {})".format(
                             colorize(safeh, 'ok'),
-                            colorize(headers.get(lsafeh), 'warning')))
+                            colorize(headers.get(lsafeh), 'warning')),
+                        output_file=output_file)
 
                 # unsafe-url policy is more insecure compared to the default/unset value
                 elif lsafeh == 'referrer-policy' and headers.get(lsafeh) == 'unsafe-url':
                     log("[!] Insecure header {} is set! (Value: {})".format(
                             colorize(safeh, 'warning'),
-                            colorize(headers.get(lsafeh), 'error')))
+                            colorize(headers.get(lsafeh), 'error')),
+                        output_file=output_file)
 
                 # check for max-age=0 in HSTS
                 elif lsafeh == 'strict-transport-security' and "max-age=0" in headers.get(lsafeh):
                     log("[!] Insecure header {} is set! (Value: {})".format(
                             colorize(safeh, 'warning'),
-                            colorize(headers.get(lsafeh), 'error')))
+                            colorize(headers.get(lsafeh), 'error')),
+                        output_file=output_file)
 
                 # Printing generic message if not specified above
                 else:
                     log("[*] Header {} is present! (Value: {})".format(
                             colorize(safeh, 'ok'),
-                            headers.get(lsafeh)))
+                            headers.get(lsafeh)),
+                        output_file=output_file)
             else:
                 unsafe += 1
                 json_results["missing"].append(safeh)
@@ -430,45 +454,55 @@ def main():
                     json_results["missing"].remove(safeh)
                     continue
                 log('[!] Security header missing: {}'.format(
-                    colorize(safeh, sec_headers.get(safeh))))
+                        colorize(safeh, sec_headers.get(safeh))),
+                    output_file=output_file)
 
         if information:
             json_results["information_disclosure"] = {}
             i_chk = False
-            log("")
+            log("", output_file=output_file)
             for infoh in information_headers:
                 linfoh = infoh.lower()
                 if linfoh in headers:
                     json_results["information_disclosure"][infoh] = headers.get(linfoh)
                     i_chk = True
-                    log("[!] Possible information disclosure: \
-header {} is present! (Value: {})".format(
+                    log("[!] Possible information disclosure: "
+                        "header {} is present! (Value: {})".format(
                             colorize(infoh, 'warning'),
-                            headers.get(linfoh)))
+                            headers.get(linfoh),
+                        output_file=output_file))
             if not i_chk:
-                log("[*] No information disclosure headers detected")
+                log("[*] No information disclosure headers detected",
+                output_file=output_file)
 
         if cache_control:
             json_results["caching"] = {}
             c_chk = False
-            log("")
+            log("", output_file=output_file)
             for cacheh in cache_headers:
                 lcacheh = cacheh.lower()
                 if lcacheh in headers:
                     json_results["caching"][cacheh] = headers.get(lcacheh)
                     c_chk = True
-                    log("[!] Cache control header {} is present! \
-(Value: {})".format(
+                    log("[!] Cache control header {} is present! "
+                        "(Value: {})".format(
                             colorize(cacheh, 'info'),
-                            headers.get(lcacheh)))
+                            headers.get(lcacheh)),
+                        output_file=output_file)
             if not c_chk:
-                log("[*] No caching headers detected")
+                log("[*] No caching headers detected",
+                    output_file=output_file)
 
-        report(rUrl, safe, unsafe)
+        report(rUrl, safe, unsafe, output_file)
         json_out.update(json_headers)
 
     if json_output:
         print(json.dumps(json_out))
+
+    if output_file:
+        if json_output:
+            output_file.write(json.dumps(json_out, indent=4))
+        output_file.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add the `-o` and `--output` flags which can be used to specify a file where the program output is written to. The output is still logged to console even when an output file is specified.
If the `--json` flag is set the output will be in JSON format. 